### PR TITLE
wrapper module

### DIFF
--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -1,0 +1,14 @@
+module "wrapper" {
+  source = "../"
+
+  for_each = var.items
+
+  name                     = try(each.value.name, var.defaults.name, null)
+  description              = try(each.value.description, var.defaults.description, null)
+  deletion_protection      = try(each.value.deletion_protection, var.defaults.deletion_protection, null)
+  labels                   = try(each.value.labels, var.defaults.labels, {})
+  zone_id                  = try(each.value.zone_id, var.defaults.zone_id, null)
+  ddos_protection_provider = try(each.value.ddos_protection_provider, var.defaults.ddos_protection_provider, null)
+  outgoing_smtp_capability = try(each.value.outgoing_smtp_capability, var.defaults.outgoing_smtp_capability, null)
+  dns_record               = try(each.value.dns_record, var.defaults.dns_record, null)
+}

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,0 +1,5 @@
+output "wrapper" {
+  description = "Map of outputs of a wrapper."
+  value       = module.wrapper
+  sensitive   = true
+}

--- a/wrappers/variables.tf
+++ b/wrappers/variables.tf
@@ -1,0 +1,11 @@
+variable "defaults" {
+  description = "Map of default values which will be used for each item."
+  type        = any
+  default     = {}
+}
+
+variable "items" {
+  description = "Maps of items to create a wrapper from. Values are passed through to the module."
+  type        = any
+  default     = {}
+}

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    yandex = {
+      source = "yandex-cloud/yandex"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+  required_version = ">= 1.3"
+}


### PR DESCRIPTION
This pull request introduces a new Terraform module wrapper in the `wrappers` directory, enabling dynamic creation of resources based on input maps with default values. Key changes include defining the module structure, adding input variables for customization, specifying required providers and Terraform version, and defining outputs for the module.

### Module Definition and Configuration:
* [`wrappers/main.tf`](diffhunk://#diff-e25ea9feee9bc4d08eb2df67afb1a69c0e9bf07580cb1604c478fbc2f10491f2R1-R14): Added a `wrapper` module that dynamically creates resources using `for_each` with support for default values via the `try` function.

### Input Variables:
* [`wrappers/variables.tf`](diffhunk://#diff-78d272b6e8f345f5d2d8aa4e55f992f2733b66659193f43612c1aafbff01ea5dR1-R11): Added `defaults` and `items` variables to allow customization and provide default values for the wrapper module.

### Outputs:
* [`wrappers/outputs.tf`](diffhunk://#diff-ca0b2f5b3caca7fcfae558fcb052e1961d06a3c1c740ec3916676208fc37f500R1-R5): Added a sensitive output `wrapper` to expose the module's outputs as a map.

### Terraform Requirements:
* [`wrappers/versions.tf`](diffhunk://#diff-fae3f8474201a9b0d80bddf286620bea79cf6f17812af6702228377452ddc53dR1-R11): Specified required providers (`yandex` and `tls`) and set the minimum Terraform version to `1.3`.